### PR TITLE
Adding filters as input to eval in manifest

### DIFF
--- a/dataloop.json
+++ b/dataloop.json
@@ -93,6 +93,11 @@
                 "type": "Dataset",
                 "name": "dataset",
                 "description": "Dataloop Dataset Entity"
+              },
+              {
+                "type": "Json",
+                "name": "filters",
+                "description": "Filter to select items over which to run evaluation"
               }
             ],
             "displayName": "Evaluate a Model",


### PR DESCRIPTION
The change was tested over yolov8-seg, and it worked there. The same thing should apply to this model.